### PR TITLE
Make Desktop version unit testable

### DIFF
--- a/Plugins/FolderPath.Desktop/FolderPathImplementation.cs
+++ b/Plugins/FolderPath.Desktop/FolderPathImplementation.cs
@@ -203,11 +203,7 @@ namespace PCLStorage
         private static string GetInternalAppName()
         {
             var assembly = System.Reflection.Assembly.GetEntryAssembly();
-            //if (assembly == null)
-            //{
-            //    assembly = System.Reflection.Assembly.GetExecutingAssembly();
-            //}
-            var appName = "";
+            var appName = "FolderPath";
             if (assembly != null)
             {
                 appName = System.IO.Path.GetFileNameWithoutExtension(assembly.Location);
@@ -221,15 +217,12 @@ namespace PCLStorage
         private static string GetInternalCompanyName()
         {
             var assembly = System.Reflection.Assembly.GetEntryAssembly();
-            //if (assembly == null)
-            //{
-            //    assembly = System.Reflection.Assembly.GetExecutingAssembly();
-            //}
-            var companyName = "";
+            var companyName = "FolderPath_Use_AssemblyCompanyAttribute_To_Change_On_Yours";
             if (assembly != null)
             {
-                var attribute = (System.Reflection.AssemblyCompanyAttribute)Attribute.GetCustomAttribute(
-                    assembly, typeof(System.Reflection.AssemblyCompanyAttribute));
+                var attribute = (System.Reflection.AssemblyCompanyAttribute)Attribute.
+                    GetCustomAttribute(assembly,
+                    typeof(System.Reflection.AssemblyCompanyAttribute));
                 companyName = attribute.Company;
             }
             return companyName;

--- a/Plugins/FolderPath.Desktop/FolderPathImplementation.cs
+++ b/Plugins/FolderPath.Desktop/FolderPathImplementation.cs
@@ -203,7 +203,7 @@ namespace PCLStorage
         private static string GetInternalAppName()
         {
             var assembly = System.Reflection.Assembly.GetEntryAssembly();
-            var appName = "FolderPath";
+            var appName = "";
             if (assembly != null)
             {
                 appName = System.IO.Path.GetFileNameWithoutExtension(assembly.Location);
@@ -217,7 +217,7 @@ namespace PCLStorage
         private static string GetInternalCompanyName()
         {
             var assembly = System.Reflection.Assembly.GetEntryAssembly();
-            var companyName = "FolderPath_Use_AssemblyCompanyAttribute_To_Change_On_Yours";
+            var companyName = "";
             if (assembly != null)
             {
                 var attribute = (System.Reflection.AssemblyCompanyAttribute)Attribute.

--- a/Plugins/FolderPath/FolderPath.cs
+++ b/Plugins/FolderPath/FolderPath.cs
@@ -8,7 +8,9 @@ namespace PCLStorage
     /// </summary>
     public class FolderPath
     {
-        static Lazy<IFolderPath> Implementation = new Lazy<IFolderPath>(() => CreateFolderPath(), System.Threading.LazyThreadSafetyMode.PublicationOnly);
+        static Lazy<IFolderPath> Implementation = new Lazy<IFolderPath>(
+            () => CreateFolderPath(),
+            System.Threading.LazyThreadSafetyMode.PublicationOnly);
 
         /// <summary>
         /// Current settings to use
@@ -23,6 +25,10 @@ namespace PCLStorage
                     throw NotImplementedInReferenceAssembly();
                 }
                 return ret;
+            }
+            set
+            {
+                Implementation = new Lazy<IFolderPath>(() => value);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ This is a common way for Xamarin Plugins described by James Montemagno in post:
 http://motzcod.es/post/159267241302/unit-testing-plugins-for-xamarin
 ```C#
 var folderPath = new Moq.Mock<IFolderPath>();
+folderPath.Setup(f => f.Local).Returns(TestContext.DeploymentDirectory);
+
 FolderPath.Current = folderPath.Object;
-var path = Path.Combine(TestContext.DeploymentDirectory, "TestData");
 ```
 
 2. Override AppName manually 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ AssemblyInfo.cs
 [assembly: AssemblyCompany("TestApp")]
 ```
 
+If you can't set the company name in the AssemblyInfo.cs for some reason, in unit tests for example. 
+You can:
+1. Use your implementation or a mock of IFolderPath.
+This is a common way for Xamarin Plugins described by James Montemagno in post:
+http://motzcod.es/post/159267241302/unit-testing-plugins-for-xamarin
+```C#
+var folderPath = new Moq.Mock<IFolderPath>();
+FolderPath.Current = folderPath.Object;
+var path = Path.Combine(TestContext.DeploymentDirectory, "TestData");
+```
+
+2. Override AppName manually 
+```C#
+((FolderPathImplementation)FolderPath.Current).AppName = "TestApp";
+((FolderPathImplementation)FolderPath.Current).CompanyName = "TestCompany";
+```
+
+
 ## License
 
 [Ms-PL](https://msdn.microsoft.com/library/gg592960.aspx "Ms-PL")


### PR DESCRIPTION
Default AppName and CompanyName have been changed from empty to values provoking to change them. Because it's impossible to set assembly's CompanyName attribute for UnitTesting process.